### PR TITLE
Fixed crash on non ascii content of the tables

### DIFF
--- a/src/ascii-table3.js
+++ b/src/ascii-table3.js
@@ -124,7 +124,7 @@ class AsciiTable3 {
                 partArray.forEach(block => result += block[0] + block[1]);
              } else {
                 // empty or single block string
-                result = str.concat(fillStr.repeat(maxLength - str.length));
+                result = str.concat(fillStr.repeat(maxLength - strlen(str)));
              }
  
              return result;


### PR DESCRIPTION
Ascii-Table3 throws `RangeError: Invalid count value`, when some unusual characters are used. Example:

```
const EMPTY = [null, null, null, null, null];
const info = {
  "map": "de_mirage",
  "home": { "score": 10, "players": ["NoHope⭕⃤ (絶望)", "𝓢𝓵𝓲𝔃𝓮𝓷𝓸𝓴"] },
  "away": { "score": 16, "players": [] },
};
const { home, away, map } = info;
const table = new AsciiTable3(map)
  .setHeading(`HOME ${home.score}`, `AWAY ${away.score}`)
  .setAlign(1, AlignmentEnum.LEFT)
  .setAlign(2, AlignmentEnum.RIGHT)
  .addRowMatrix(
    EMPTY.map((_, i) => [home.players[i] || "-", away.players[i] || "-"]),
  );

table.setStyle("unicode-mix");
const content = table.toString();
console.log(content);

```

It seems that an issue is `strlen(str) >= maxLength` check on line 105 in  src/ascii-table3.js, and then doing `fillStr.repeat(maxLength - str.length)` - `str.length` in this case has different value then `strlen(str)`, so `repeat` method is being feed a negative value in this case, throwing an error.